### PR TITLE
feat(005): start timer on stage enter

### DIFF
--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -18,7 +18,7 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
     set({
       stageId,
       queens: [],
-      timerStartedAt: null,
+      timerStartedAt: Date.now(),
       elapsedSeconds: 0,
       isSolved: false,
       isNewRecord: false,
@@ -34,16 +34,10 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
 
     const newQueens = toggleQueen(state.queens, coord)
 
-    // Start the timer on first queen placement
-    const timerStartedAt =
-      newQueens.length > 0 && state.timerStartedAt === null
-        ? Date.now()
-        : state.timerStartedAt
-
     const stage = STAGES[state.stageId]
     const solved = stage ? isSolved(newQueens, stage) : false
 
-    set({ queens: newQueens, timerStartedAt, isSolved: solved })
+    set({ queens: newQueens, isSolved: solved })
   },
 
   cycleCell(coord: CellCoord) {
@@ -74,10 +68,6 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
       // X-marked → Queen: remove manual mark, place queen
       const newManualMarks = state.manualMarks.filter((k) => k !== key)
       const newQueens = [...state.queens, { row: coord.row, col: coord.col }]
-      const timerStartedAt =
-        newQueens.length > 0 && state.timerStartedAt === null
-          ? Date.now()
-          : state.timerStartedAt
 
       // Apply auto-marks for the newly placed queen if toggle is on
       let newAutoMarksByQueen = state.autoMarksByQueen
@@ -98,7 +88,6 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
         queens: newQueens,
         manualMarks: newManualMarks,
         autoMarksByQueen: newAutoMarksByQueen,
-        timerStartedAt,
         isSolved: solved,
       })
     } else {
@@ -150,8 +139,6 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
   restart() {
     set({
       queens: [],
-      timerStartedAt: null,
-      elapsedSeconds: 0,
       isSolved: false,
       isNewRecord: false,
       manualMarks: [],


### PR DESCRIPTION
Closes #8

## Summary

- `loadStage` now sets `timerStartedAt: Date.now()` so the timer begins the moment a stage is entered
- `restart` no longer resets `timerStartedAt` or `elapsedSeconds` — it only clears the board state (queens, marks)
- Removed the dead "start timer on first queen" logic from `cycleCell` and `placeOrRemoveQueen`

## Test plan

- [ ] Enter a stage — timer starts counting immediately without placing anything
- [ ] Press Reset — board clears but timer keeps running from where it left off
- [ ] Complete a puzzle — elapsed time is saved correctly as best time