### PR TITLE
feat(006): Settings tab with persistent auto-mark toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ confirmed RED before the corresponding implementation is written.
 
 ## Recent Changes
 
+- 006-settings-automark: Settings tab on Stage Select — Auto-mark toggle moved from PuzzlePage, persisted via `queems-settings` (localStorage), new `settings-store.ts`, default ON
 - 003-drag-mark-x: Click-and-drag X marking — `useDragMark` hook, `addManualMark` store action, Cell/Board drag props
 - 002-mark-cells: Three-state cell cycle (empty → X → queen), Auto-Mark toggle, `computeInvalidationSet` pure fn
 - 001-queens-mock: Initial project — full Vite SPA + React 19 + TypeScript 5 stack

--- a/specs/006-settings-automark/checklists/requirements.md
+++ b/specs/006-settings-automark/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Settings Tab with Persisted Auto-Mark Toggle
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/006-settings-automark/data-model.md
+++ b/specs/006-settings-automark/data-model.md
@@ -1,0 +1,89 @@
+# Data Model: Settings Tab with Persisted Auto-Mark Toggle
+
+**Feature**: 006-settings-automark
+**Date**: 2026-02-19
+
+---
+
+## New Entity: AppSettings
+
+Represents global user preferences that survive between sessions.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `autoMarkEnabled` | `boolean` | `true` | Whether invalid cells are automatically marked with X when a queen is placed |
+
+**Validation rules**:
+- Must be a strict boolean (no `undefined`, no string coercion)
+- Default is `true` — new users get the feature enabled
+
+**Persistence**:
+- Stored in `localStorage` under key `queems-settings`
+- Written immediately on every toggle change
+- Read synchronously at app startup and at stage load
+
+---
+
+## New Store: SettingsState
+
+Zustand persistent store that owns `AppSettings`.
+
+| Member | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `autoMarkEnabled` | state field | `boolean` | Current value of the setting |
+| `setAutoMark` | action | `(value: boolean) => void` | Overwrite the setting with a new value and persist |
+
+**localStorage key**: `queems-settings`
+**Migration**: None required — first read with an empty store returns the default value `true`.
+
+---
+
+## Modified Entity: GameSession (existing)
+
+The `autoMarkEnabled` field already exists in `GameSession`. The only change is how it is initialized.
+
+| Field | Previous default | New initialization |
+|-------|-----------------|-------------------|
+| `autoMarkEnabled` | Hard-coded `false` in `loadStage` | Read from `useSettingsStore.getState().autoMarkEnabled` in `loadStage` |
+
+---
+
+## Removed Action: `toggleAutoMark` (from GameStoreState)
+
+This action is removed because:
+- It was the in-game toggle handler, only called from `PuzzlePage`
+- The toggle moves to `StageSelectPage` (Settings tab), which writes directly to `SettingsStore`
+- During a puzzle session, `autoMarkEnabled` is fixed at stage-load time (not toggled mid-game)
+
+**Replacement**: `useSettingsStore.setAutoMark(value)` called from the Settings tab component.
+
+---
+
+## State Transitions
+
+```
+First visit (no localStorage):
+  SettingsStore initializes → autoMarkEnabled = true (default)
+
+User toggles OFF in Settings tab:
+  setAutoMark(false) → autoMarkEnabled = false → persisted to localStorage
+
+User starts puzzle:
+  loadStage(stageId) → reads useSettingsStore.getState().autoMarkEnabled
+                     → GameSession.autoMarkEnabled = false (reflects saved pref)
+
+User toggles ON in Settings tab (after navigating back):
+  setAutoMark(true) → autoMarkEnabled = true → persisted to localStorage
+
+User starts next puzzle:
+  loadStage(stageId) → reads useSettingsStore.getState().autoMarkEnabled
+                     → GameSession.autoMarkEnabled = true
+```
+
+---
+
+## UI State (ephemeral, not persisted)
+
+| Component | State | Type | Description |
+|-----------|-------|------|-------------|
+| `StageSelectPage` | `activeTab` | `'stages' \| 'settings'` | Which tab is currently visible; resets to `'stages'` on page reload |

--- a/specs/006-settings-automark/plan.md
+++ b/specs/006-settings-automark/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: Settings Tab with Persisted Auto-Mark Toggle
+
+**Branch**: `006-settings-automark` | **Date**: 2026-02-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/006-settings-automark/spec.md`
+
+## Summary
+
+Move the "Auto-mark invalid cells" toggle out of `PuzzlePage` into a new Settings tab on `StageSelectPage`. The preference defaults to ON, is persisted in `localStorage` via a new `settings-store` (Zustand persist), and is applied whenever a puzzle stage loads. The Settings tab uses the app's existing amber/gray design language and a custom styled toggle switch.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 (strict mode, `any` forbidden)
+**Primary Dependencies**: React 19, Vite 6, Tailwind CSS v4, Zustand 5 (with persist middleware), Framer Motion v11, Lucide React
+**Storage**: `localStorage` — new key `queems-settings` (existing: `queems-best-times`)
+**Testing**: Vitest 2 + @testing-library/react
+**Target Platform**: SPA — all modern browsers
+**Project Type**: Single-project web SPA (`src/`)
+**Performance Goals**: Instant toggle response; no noticeable latency on settings read at stage load
+**Constraints**: No new runtime dependencies; no network calls; offline-capable
+**Scale/Scope**: Single boolean setting; two-tab UI on one page
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Spec-First** | ✅ PASS | `spec.md` exists, reviewed, no NEEDS CLARIFICATION markers |
+| **II. Puzzle Rule Integrity** | ✅ PASS | No game logic changes; `settings-store` is pure persistence; `autoMarkEnabled` initialization path change is mechanical |
+| **III. Component-First** | ✅ PASS | Settings tab will be a focused UI section; no game logic in JSX; settings state lives in `settings-store` |
+| **IV. Test-First for Logic** | ✅ PASS | `settings-store.test.ts` written RED before implementation; `game-store.test.ts` updated before store changes |
+| **V. YAGNI** | ✅ PASS | One boolean added; `toggleAutoMark` removed (dead code); no speculative settings or abstractions |
+
+**Post-design re-check**: All five gates pass. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-settings-automark/
+├── plan.md              ← This file
+├── research.md          ← Phase 0 — decisions and rationale
+├── data-model.md        ← Phase 1 — entities, state transitions, store contracts
+├── quickstart.md        ← Phase 1 — how to run and verify
+├── checklists/
+│   └── requirements.md  ← Spec quality checklist (all green)
+└── tasks.md             ← Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code Changes
+
+```text
+src/
+├── types/
+│   └── index.ts                   ← MODIFY: add AppSettings, SettingsState;
+│                                             remove toggleAutoMark from GameStoreState
+├── stores/
+│   ├── settings-store.ts          ← NEW: Zustand persist store, key queems-settings
+│   └── game-store.ts              ← MODIFY: loadStage reads settings store;
+│                                             remove toggleAutoMark action
+└── pages/
+    ├── StageSelectPage.tsx        ← MODIFY: add tab nav + Settings tab with toggle
+    └── PuzzlePage.tsx             ← MODIFY: remove Auto-mark toggle UI
+
+tests/
+└── logic/
+    ├── settings-store.test.ts     ← NEW: TDD unit tests (RED → GREEN)
+    └── game-store.test.ts         ← MODIFY: remove toggleAutoMark tests;
+                                             update loadStage init expectations
+```
+
+**Structure Decision**: Single-project SPA (Option 1). No new directories needed; `settings-store.ts` fits in the existing `src/stores/` directory alongside `best-times-store.ts`.
+
+## Phase 0: Research Summary
+
+All findings consolidated in [research.md](./research.md). No NEEDS CLARIFICATION markers were present in the spec. Key decisions:
+
+1. **Persistence**: Zustand `persist` middleware, key `queems-settings`, mirrors `best-times-store.ts` exactly.
+2. **Cross-store read**: `loadStage` calls `useSettingsStore.getState().autoMarkEnabled` — synchronous, no subscription.
+3. **Dead code removal**: `toggleAutoMark` action removed from `game-store` and `GameStoreState` interface.
+4. **Tab design**: Pill-style tabs, active = `bg-amber-400 text-white`, inactive = `text-gray-500`.
+5. **Toggle design**: Custom CSS-transition sliding switch using Tailwind v4 classes; no new motion libraries.
+
+## Phase 1: Design & Contracts
+
+### New Types (`src/types/index.ts`)
+
+```typescript
+// NEW — persistent app settings
+export interface AppSettings {
+  autoMarkEnabled: boolean
+}
+
+// NEW — settings store shape
+export interface SettingsState extends AppSettings {
+  setAutoMark: (value: boolean) => void
+}
+```
+
+`GameStoreState` change: **remove** `toggleAutoMark: () => void` from the interface.
+
+### New Store (`src/stores/settings-store.ts`)
+
+```typescript
+// Zustand persist store — key: queems-settings — default autoMarkEnabled: true
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      autoMarkEnabled: true,
+      setAutoMark(value: boolean) { set({ autoMarkEnabled: value }) },
+    }),
+    { name: 'queems-settings' },
+  ),
+)
+```
+
+### Modified Store (`src/stores/game-store.ts`)
+
+In `loadStage`:
+```typescript
+// BEFORE
+autoMarkEnabled: false,
+
+// AFTER
+autoMarkEnabled: useSettingsStore.getState().autoMarkEnabled,
+```
+
+Remove entire `toggleAutoMark` action.
+
+### Settings Tab Toggle Component (inline in `StageSelectPage.tsx`)
+
+The toggle is a small inline presentational element — not complex enough to warrant its own file (YAGNI).
+
+```tsx
+// Accessible toggle switch — pure Tailwind v4 + CSS transition
+<button
+  role="switch"
+  aria-checked={autoMarkEnabled}
+  aria-label="Auto-mark invalid cells"
+  onClick={() => setAutoMark(!autoMarkEnabled)}
+  className={cn(
+    'relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200',
+    autoMarkEnabled ? 'bg-amber-400' : 'bg-gray-300',
+  )}
+>
+  <span
+    className={cn(
+      'inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200',
+      autoMarkEnabled ? 'translate-x-6' : 'translate-x-1',
+    )}
+  />
+</button>
+```
+
+### Contracts
+
+No HTTP API contracts — this is a purely client-side feature. The store interface in `data-model.md` serves as the contract between the Settings tab UI and the settings store.
+
+### TDD Test Outline (`tests/logic/settings-store.test.ts`)
+
+Tests to write RED before implementing the store:
+
+```text
+describe('useSettingsStore')
+  it('defaults autoMarkEnabled to true')
+  it('setAutoMark(false) sets autoMarkEnabled to false')
+  it('setAutoMark(true) sets autoMarkEnabled to true after it was false')
+  it('setAutoMark is idempotent — calling with same value is a no-op (state unchanged)')
+```
+
+`game-store.test.ts` changes:
+- Remove any `toggleAutoMark` describe block
+- Add test: `loadStage initializes autoMarkEnabled from settings store`

--- a/specs/006-settings-automark/quickstart.md
+++ b/specs/006-settings-automark/quickstart.md
@@ -1,0 +1,101 @@
+# Quickstart: Settings Tab with Persisted Auto-Mark Toggle
+
+**Feature**: 006-settings-automark
+**Branch**: `006-settings-automark`
+**Date**: 2026-02-19
+
+---
+
+## Prerequisites
+
+- Node.js 20+ and pnpm installed
+- Repo cloned, dependencies installed (`pnpm install`)
+- Branch `006-settings-automark` checked out
+
+```bash
+git checkout 006-settings-automark
+pnpm install   # if not already done
+```
+
+---
+
+## Run Dev Server
+
+```bash
+pnpm dev
+# → http://localhost:5173
+```
+
+Navigate to `/` to see the Stage Select page with the new "Stages" / "Settings" tabs.
+
+---
+
+## Run Tests
+
+```bash
+pnpm vitest                      # run all tests once
+pnpm vitest --watch              # watch mode during development
+pnpm vitest tests/logic/settings-store.test.ts  # run only settings-store tests
+```
+
+**TDD order** (per Constitution IV):
+1. Write `tests/logic/settings-store.test.ts` → confirm RED
+2. Implement `src/stores/settings-store.ts` → confirm GREEN
+3. Update `tests/logic/game-store.test.ts` → confirm RED for changed behavior
+4. Update `src/stores/game-store.ts` → confirm GREEN
+
+---
+
+## Implementation Order (dependency-safe)
+
+```
+1. src/types/index.ts              ← Add AppSettings, SettingsState; remove toggleAutoMark
+2. tests/logic/settings-store.test.ts  ← Write RED tests (TDD)
+3. src/stores/settings-store.ts    ← Implement (make tests GREEN)
+4. src/stores/game-store.ts        ← Update loadStage to read settings; remove toggleAutoMark
+5. tests/logic/game-store.test.ts  ← Update for removed toggleAutoMark
+6. src/pages/PuzzlePage.tsx        ← Remove toggle UI and toggleAutoMark destructuring
+7. src/pages/StageSelectPage.tsx   ← Add tabs + Settings tab with styled toggle
+```
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/stores/settings-store.ts` | NEW — persisted settings store |
+| `src/types/index.ts` | MODIFIED — new `AppSettings` / `SettingsState` types; `GameStoreState` loses `toggleAutoMark` |
+| `src/stores/game-store.ts` | MODIFIED — `loadStage` reads settings store; `toggleAutoMark` removed |
+| `src/pages/StageSelectPage.tsx` | MODIFIED — tab navigation + Settings tab |
+| `src/pages/PuzzlePage.tsx` | MODIFIED — remove Auto-mark toggle |
+| `tests/logic/settings-store.test.ts` | NEW — TDD unit tests |
+| `tests/logic/game-store.test.ts` | MODIFIED — remove `toggleAutoMark` tests |
+
+---
+
+## Verify the Feature
+
+1. Open `http://localhost:5173`
+2. Confirm two tabs are visible: **Stages** and **Settings**
+3. Click **Settings** — confirm the "Auto-mark invalid cells" toggle is ON by default
+4. Toggle it OFF — confirm the toggle animates and the label updates
+5. Hard-refresh the page — confirm Settings tab still shows the toggle as OFF
+6. Click **Stages**, start a puzzle, place a queen — confirm NO cells are auto-marked
+7. Go back, open Settings, toggle ON
+8. Start a puzzle, place a queen — confirm invalid cells ARE auto-marked
+9. Open browser DevTools → Application → localStorage — confirm `queems-settings` key exists with `{"state":{"autoMarkEnabled":false},"version":0}` (or `true`)
+10. Confirm the Auto-mark toggle is ABSENT from the puzzle page
+
+---
+
+## Design Reference
+
+The Settings tab uses the app's existing design tokens:
+- Background: `bg-gray-50` (matches page background)
+- Active tab: `bg-amber-400 text-white` (matches Crown icon color)
+- Inactive tab: `text-gray-500 hover:text-gray-700`
+- Toggle track ON: `bg-amber-400`
+- Toggle track OFF: `bg-gray-300`
+- Toggle thumb: `bg-white` with `shadow-sm`
+- Typography: same `text-sm` / `text-gray-600` as existing labels

--- a/specs/006-settings-automark/research.md
+++ b/specs/006-settings-automark/research.md
@@ -1,0 +1,83 @@
+# Research: Settings Tab with Persisted Auto-Mark Toggle
+
+**Feature**: 006-settings-automark
+**Date**: 2026-02-19
+**Status**: Complete — no NEEDS CLARIFICATION markers in spec
+
+---
+
+## Decision 1: Settings Persistence Pattern
+
+**Decision**: Use Zustand `persist` middleware with `localStorage`, key `queems-settings` — mirroring the existing `best-times-store.ts` pattern exactly.
+
+**Rationale**: The project already uses this pattern for `best-times-store`. Consistency avoids a second persistence mechanism, keeps the codebase idiomatic, and requires zero new dependencies.
+
+**Alternatives considered**:
+- Raw `localStorage` API calls — rejected: doesn't integrate with Zustand reactivity; violates Component-First principle (logic in components)
+- `sessionStorage` — rejected: doesn't survive browser close (spec requires persistence)
+- Separate cookie — rejected: overkill for a simple boolean flag
+
+---
+
+## Decision 2: Cross-Store Dependency in `loadStage`
+
+**Decision**: `game-store.ts` `loadStage` reads `useSettingsStore.getState().autoMarkEnabled` at call time to initialize the game session's `autoMarkEnabled` field.
+
+**Rationale**: Zustand's `getState()` is a synchronous read with no subscription cost. This is the idiomatic Zustand pattern for one-time cross-store reads. It avoids subscribing the game store to settings store updates (which would add unnecessary complexity per YAGNI).
+
+**Alternatives considered**:
+- Subscribe `game-store` to `settings-store` changes — rejected: over-engineering for a setting that only matters at stage load time
+- Pass `autoMarkEnabled` as a parameter to `loadStage` — rejected: callers would need to import settings store, spreading the concern unnecessarily
+- Single store combining both — rejected: violates single-responsibility; best-times and settings are unrelated domains
+
+---
+
+## Decision 3: Remove `toggleAutoMark` from Game Store
+
+**Decision**: Remove the `toggleAutoMark` action from `game-store.ts` and from the `GameStoreState` interface. The Settings store's `setAutoMark` action replaces it.
+
+**Rationale**: `toggleAutoMark` was only called from `PuzzlePage.tsx`. Once the toggle moves to `StageSelectPage`, the in-game toggle action becomes dead code. Per YAGNI (Constitution V), dead code must not be retained.
+
+**Alternatives considered**:
+- Keep `toggleAutoMark` as a no-op fallback — rejected: YAGNI forbids dead code
+- Rename to `_toggleAutoMark` — rejected: unused private methods are still dead code
+
+**Impact**: `GameStoreState` interface loses one action; existing test coverage for `toggleAutoMark` is deleted.
+
+---
+
+## Decision 4: Tab UI Pattern
+
+**Decision**: Pill-style tab bar with two tabs ("Stages" / "Settings"). Active tab: `bg-amber-400 text-white` (matching the Crown icon). Inactive tab: `text-gray-500 hover:text-gray-700`. Tab state is local React `useState` — ephemeral, not persisted.
+
+**Rationale**: Amber-400 is already the app's primary accent color (Crown icon, future stage markers). Using it as the active-tab indicator creates visual consistency with zero new design tokens. A pill style is lighter-weight than a full underline or bordered tab, fitting the app's minimal aesthetic.
+
+**Alternatives considered**:
+- Underline tabs — rejected: requires more DOM structure; feels heavier for a two-item tab bar
+- Separate route `/settings` — rejected: overkill; settings is a lightweight panel, not a full page
+
+---
+
+## Decision 5: Toggle Switch Design
+
+**Decision**: A custom-styled toggle switch (sliding pill) using pure Tailwind v4 classes and a CSS `transition`. Track color: `bg-amber-400` (ON) / `bg-gray-200` (OFF). Thumb: white circle. No Framer Motion dependency for the thumb (CSS transition suffices and avoids library overhead for a simple boolean).
+
+**Rationale**: The existing UI uses plain Tailwind transitions elsewhere (e.g., hover states on buttons). A CSS transition on the thumb translate is sufficient and consistent. Using `framer-motion` for a simple toggle would be over-engineering (Constitution V).
+
+**Alternatives considered**:
+- Plain `<input type="checkbox">` — rejected: spec requires enhanced visuals cohesive with the app
+- Framer Motion `AnimatePresence` — rejected: overkill; simple CSS `transition` covers this use case
+
+---
+
+## Summary of Files Affected
+
+| File | Change Type | Reason |
+|------|-------------|--------|
+| `src/stores/settings-store.ts` | **NEW** | Persisted settings with `autoMarkEnabled: true` default |
+| `src/types/index.ts` | **MODIFY** | Add `AppSettings`, `SettingsState`; remove `toggleAutoMark` from `GameStoreState` |
+| `src/stores/game-store.ts` | **MODIFY** | `loadStage` reads from settings store; remove `toggleAutoMark` action |
+| `src/pages/StageSelectPage.tsx` | **MODIFY** | Add tab navigation + Settings tab with styled toggle |
+| `src/pages/PuzzlePage.tsx` | **MODIFY** | Remove Auto-mark toggle UI and `toggleAutoMark` import |
+| `tests/logic/settings-store.test.ts` | **NEW** | TDD tests (written RED before implementation) |
+| `tests/logic/game-store.test.ts` | **MODIFY** | Remove `toggleAutoMark` tests; update `loadStage` init test |

--- a/specs/006-settings-automark/spec.md
+++ b/specs/006-settings-automark/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Settings Tab with Persisted Auto-Mark Toggle
+
+**Feature Branch**: `006-settings-automark`
+**Created**: 2026-02-19
+**Status**: Draft
+**Input**: User description: "Move the 'Auto-mark invalid cells' toggle from PuzzlePage to StageSelectPage, put it in a settings tab, default on, persist in localStorage, enhanced visuals"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Access and Toggle Auto-Mark from Settings (Priority: P1)
+
+A player visits the Stage Select screen and wants to control whether invalid cells are automatically highlighted when they place a queen. They find a "Settings" tab on the Stage Select page, toggle Auto-mark on or off, and this preference is remembered the next time they open the app.
+
+**Why this priority**: This is the core of the feature — relocating the setting to the right place and making it persistent. Without this, there is no feature.
+
+**Independent Test**: Navigate to the Stage Select page, open the Settings tab, toggle the Auto-mark control, close the browser, reopen, and confirm the setting was retained.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Stage Select page, **When** they open the Settings tab, **Then** they see an "Auto-mark invalid cells" toggle that reflects the currently saved preference.
+2. **Given** Auto-mark is OFF, **When** the user enables it in Settings, **Then** the preference is saved immediately to persistent storage.
+3. **Given** Auto-mark is ON, **When** the user disables it in Settings, **Then** the preference is saved immediately to persistent storage.
+4. **Given** a first-time user (no saved preference), **When** they open Settings, **Then** Auto-mark defaults to ON.
+5. **Given** the user saved a preference and closed the app, **When** they reopen and visit Settings, **Then** their saved preference is shown and applied.
+
+---
+
+### User Story 2 - Auto-Mark Setting Applies in Puzzle (Priority: P2)
+
+After the user sets their Auto-mark preference in Settings, they start a puzzle. The behavior during gameplay reflects whatever was chosen in Settings — no toggle is shown in the puzzle UI.
+
+**Why this priority**: The setting must actually affect gameplay. Without this story the UI change is cosmetic only.
+
+**Independent Test**: Set Auto-mark ON in Settings, start any puzzle, place a queen, verify invalid cells are marked automatically. Then set it OFF, restart the puzzle, and verify no auto-marks appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** Auto-mark is ON in Settings, **When** the user starts a puzzle and places a queen, **Then** invalid cells are automatically marked with X.
+2. **Given** Auto-mark is OFF in Settings, **When** the user starts a puzzle and places a queen, **Then** no cells are auto-marked.
+3. **Given** a puzzle was in progress, **When** the user navigates back and changes Auto-mark in Settings, **Then** starting a new puzzle respects the updated setting.
+
+---
+
+### User Story 3 - Visually Cohesive Settings Tab (Priority: P3)
+
+The Settings tab on the Stage Select page looks and feels like a natural part of the app — matching the existing design language (color palette, typography, spacing, component style) rather than feeling like an afterthought.
+
+**Why this priority**: Visual polish improves user trust but does not block functionality.
+
+**Independent Test**: A person unfamiliar with the codebase can view the Settings tab screenshot and reasonably conclude it belongs to the same design system as the rest of the app.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Stage Select page, **When** the Settings tab is active, **Then** the toggle control uses the app's established color scheme (amber/gray tones) and typography.
+2. **Given** the Settings tab is visible, **When** the toggle is switched, **Then** there is a smooth visual transition consistent with the rest of the UI.
+3. **Given** both the "Stages" tab and the "Settings" tab are present, **When** the user switches between them, **Then** the active tab is clearly distinguished from the inactive one.
+
+---
+
+### Edge Cases
+
+- What happens when localStorage is unavailable or throws an error? The feature must degrade gracefully, defaulting to Auto-mark ON without crashing.
+- What if the user navigates directly to a puzzle URL without visiting Stage Select? The puzzle must still read the persisted preference (or use the default ON).
+- What happens if a puzzle is currently in progress when the setting changes (via browser back + Settings tab)? The updated setting applies to the next queen placement or new puzzle load.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Stage Select page MUST display tab navigation with at least two tabs: "Stages" (existing stage grid) and "Settings".
+- **FR-002**: The Settings tab MUST contain an "Auto-mark invalid cells" toggle control with a label and descriptive supporting text.
+- **FR-003**: The Auto-mark toggle MUST default to ON for first-time users (no stored preference).
+- **FR-004**: The Auto-mark toggle state MUST be persisted to localStorage immediately when changed, using the storage key `queems-settings`.
+- **FR-005**: The persisted Auto-mark setting MUST be read and applied to gameplay before any puzzle begins.
+- **FR-006**: The Auto-mark toggle MUST be removed from PuzzlePage — it must no longer appear during active gameplay.
+- **FR-007**: The game session initialization MUST read Auto-mark preference from the persisted settings store, not use a hard-coded default.
+- **FR-008**: The Settings tab UI MUST use the app's established visual language (colors, fonts, spacing, motion) to feel cohesive.
+- **FR-009**: Tab switching between "Stages" and "Settings" MUST have a clear active/inactive visual state.
+- **FR-010**: Toggle and tab controls MUST be keyboard-navigable and have appropriate accessible labels.
+
+### Key Entities
+
+- **AppSettings**: Global user preferences, persisted in localStorage. Key attribute: `autoMarkEnabled` (boolean, default `true`).
+- **SettingsStore**: A new persistent store that owns `AppSettings` and exposes a `setAutoMark(value: boolean)` action. Analogous to the existing best-times store.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Auto-mark preference survives a full browser close and reopen — verified in 100% of automated test cases.
+- **SC-002**: The Auto-mark toggle is absent from PuzzlePage across all puzzle stages — verified by inspection of rendered output.
+- **SC-003**: The Settings tab is reachable within one interaction (one click/tap) from the Stage Select page.
+- **SC-004**: First-time users (cleared localStorage) see Auto-mark enabled by default — verified across all supported browsers.
+- **SC-005**: The Settings tab visual design passes a side-by-side comparison with existing UI components and is judged consistent by a reviewer unfamiliar with the code.
+
+## Assumptions
+
+- The `queems-settings` localStorage key is new and does not conflict with the existing `queems-best-times` key.
+- The "Stages" tab represents the existing stage grid content that currently fills the entire Stage Select page.
+- Tab selection state (which tab is active) is ephemeral — it resets to "Stages" on page reload and is not persisted.
+- Only one setting exists in this iteration; the Settings tab structure should accommodate future additions without a redesign (but no speculative settings are added now).
+- The existing `autoMarkEnabled` field in the game store remains but is initialized from the settings store rather than being hard-coded.

--- a/specs/006-settings-automark/tasks.md
+++ b/specs/006-settings-automark/tasks.md
@@ -1,0 +1,189 @@
+# Tasks: Settings Tab with Persisted Auto-Mark Toggle
+
+**Input**: Design documents from `/specs/006-settings-automark/`
+**Branch**: `006-settings-automark`
+**Date**: 2026-02-19
+**Prerequisites**: plan.md ✅ | spec.md ✅ | research.md ✅ | data-model.md ✅ | quickstart.md ✅
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in all task descriptions
+
+---
+
+## Phase 1: Setup (Shared Types)
+
+**Purpose**: Add new types and remove dead type signatures — foundational for ALL subsequent work. No code can compile without this.
+
+- [x] T001 Add `AppSettings` and `SettingsState` interfaces to `src/types/index.ts`; remove `toggleAutoMark: () => void` from `GameStoreState`
+
+**Checkpoint**: TypeScript types compile; all dependent files show errors only for removed `toggleAutoMark` (expected — resolved in Phase 4)
+
+---
+
+## Phase 2: Foundational (Settings Store)
+
+**Purpose**: New persistent settings store that ALL user stories depend on. Must be complete and tested before any UI work.
+
+**⚠️ CRITICAL**: User story 1 cannot be implemented until this phase is complete (UI reads from this store)
+
+- [x] T002 Write RED unit tests for `useSettingsStore` in `tests/logic/settings-store.test.ts` — cover: default `autoMarkEnabled: true`, `setAutoMark(false)`, `setAutoMark(true)`, idempotent call
+- [x] T003 Implement `src/stores/settings-store.ts` using Zustand `persist` middleware (key: `queems-settings`, default `autoMarkEnabled: true`) — confirm T002 tests turn GREEN
+
+**Checkpoint**: `pnpm vitest tests/logic/settings-store.test.ts` → all tests GREEN
+
+---
+
+## Phase 3: User Story 1 — Access and Toggle Auto-Mark from Settings (Priority: P1) 🎯 MVP
+
+**Goal**: Stage Select page has "Stages" / "Settings" pill tab navigation; Settings tab contains a working, persisted Auto-mark toggle defaulting to ON.
+
+**Independent Test**: Navigate to `/`, click Settings tab, toggle Auto-mark OFF, hard-refresh — confirm tab shows the toggle still OFF and `queems-settings` key in localStorage contains `false`.
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Add `activeTab` local state (`'stages' | 'settings'`) and render pill tab bar ("Stages" / "Settings") to `src/pages/StageSelectPage.tsx` — active tab: `bg-amber-400 text-white rounded-full`, inactive: `text-gray-500 hover:text-gray-700`
+- [x] T005 [US1] Implement Settings tab content in `src/pages/StageSelectPage.tsx`: read `autoMarkEnabled` and `setAutoMark` from `useSettingsStore`; render styled toggle switch (`role="switch"`, `aria-checked`, amber-400 track when ON / gray-300 when OFF, CSS `transition` on thumb translate, descriptive label and supporting sub-text)
+
+**Checkpoint**: User Story 1 fully functional — Settings tab visible, toggle persists across page reload, default is ON for new users
+
+---
+
+## Phase 4: User Story 2 — Auto-Mark Setting Applies in Puzzle (Priority: P2)
+
+**Goal**: When a puzzle loads, `autoMarkEnabled` in the game session is initialized from the persisted setting (not hard-coded `false`). The Auto-mark toggle is removed from `PuzzlePage`. `toggleAutoMark` action is deleted.
+
+**Independent Test**: Set Auto-mark OFF in Settings, navigate to any puzzle, place a queen — no cells auto-mark. Set it ON, start a new puzzle, place a queen — invalid cells auto-mark.
+
+### Implementation for User Story 2
+
+- [x] T006 [US2] Update `tests/logic/game-store.test.ts`: remove `toggleAutoMark` describe block; add test asserting `loadStage` sets `autoMarkEnabled` to the value returned by `useSettingsStore.getState()` — confirm test is RED before T007
+- [x] T007 [P] [US2] Update `src/stores/game-store.ts`: in `loadStage`, replace `autoMarkEnabled: false` with `autoMarkEnabled: useSettingsStore.getState().autoMarkEnabled`; remove entire `toggleAutoMark` action — confirm T006 tests turn GREEN
+- [x] T008 [P] [US2] Remove Auto-mark toggle UI (label + checkbox, currently lines 143–153) and `toggleAutoMark` from destructured `useGameStore()` in `src/pages/PuzzlePage.tsx`
+
+**Checkpoint**: `pnpm vitest tests/logic/game-store.test.ts` → all GREEN; puzzle page has no toggle; auto-mark behavior follows Settings preference
+
+---
+
+## Phase 5: User Story 3 — Visually Cohesive Settings Tab (Priority: P3)
+
+**Goal**: The Settings tab looks and feels native to the app: amber accent for active tab, smooth toggle animation, accessible labels, and descriptive supporting text that non-technical users understand.
+
+**Independent Test**: View Settings tab side-by-side with Stage Select header and StageCard components — typography, spacing, and color usage are visually consistent.
+
+### Implementation for User Story 3
+
+- [x] T009 [P] [US3] Refine tab bar in `src/pages/StageSelectPage.tsx`: add `transition-colors duration-150` on tab buttons; ensure `aria-selected` and `role="tab"` / `role="tablist"` / `role="tabpanel"` ARIA attributes are present for full keyboard accessibility
+- [x] T010 [P] [US3] Refine Settings tab content in `src/pages/StageSelectPage.tsx`: add supporting description text below toggle label (e.g. "Automatically marks cells that would violate the rules when you place a queen"); confirm toggle thumb uses `transition-transform duration-200`; ensure toggle container has adequate touch target size (`min-h-[44px]`)
+
+**Checkpoint**: All three user stories work together; visual design passes side-by-side comparison with existing components
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify full integration, confirm build health, and update project documentation.
+
+- [x] T011 Run `pnpm vitest` and confirm all tests pass (settings-store + game-store + existing suites)
+- [x] T012 [P] Run `pnpm eslint src --ext .ts,.tsx` and resolve any lint errors introduced by this feature
+- [x] T013 [P] Run `pnpm build` and confirm the production build succeeds with no TypeScript errors
+- [x] T014 Update `CLAUDE.md` Recent Changes section: add `006-settings-automark: Settings tab on Stage Select — Auto-mark toggle moved, persisted (queems-settings), new settings-store`
+
+**Checkpoint**: `pnpm build` exits 0; all tests GREEN; CLAUDE.md updated
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on T001 (types); BLOCKS US1 implementation
+- **Phase 3 (US1)**: Depends on Phase 2 completion (T003 GREEN)
+- **Phase 4 (US2)**: Depends on Phase 2 completion; US1 not required (different files)
+- **Phase 5 (US3)**: Depends on Phase 3 (refines same UI)
+- **Phase 6 (Polish)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires Phase 2 (settings store) — no dependency on US2 or US3
+- **US2 (P2)**: Requires Phase 2 (settings store) — no dependency on US1 or US3; can run in parallel with US1
+- **US3 (P3)**: Requires US1 Phase 3 (refines the same component)
+
+### Within Each Phase
+
+- T002 (write RED tests) MUST complete and FAIL before T003 (implementation) — Constitution IV
+- T006 (write RED tests) MUST complete and FAIL before T007 (implementation)
+- T007 and T008 are marked [P] — different files, safe to run after T006
+
+### Parallel Opportunities
+
+- After T001: T002 can start immediately
+- After T003 (Phase 2 done): T004 (US1) and T006 (US2 tests) can start in parallel
+- After T006: T007 and T008 can run in parallel (different files)
+- After T004: T005 can start immediately (same file, sequential)
+- T009 and T010 can run in parallel (same file but independent sections — or treat as one task if preferred)
+- T011, T012, T013 can run in parallel in the final polish phase
+
+---
+
+## Parallel Example: Phase 4 (US2)
+
+```text
+Step 1 — sequential:
+  T006: Update tests/logic/game-store.test.ts (write RED tests)
+
+Step 2 — parallel (after T006 is confirmed RED):
+  Task A: T007 — Update src/stores/game-store.ts (loadStage + remove toggleAutoMark)
+  Task B: T008 — Remove toggle from src/pages/PuzzlePage.tsx
+```
+
+## Parallel Example: Phase 3+4 (after Phase 2)
+
+```text
+After T003 is GREEN, two tracks can proceed independently:
+
+Track 1 — User Story 1:
+  T004 → T005
+
+Track 2 — User Story 2:
+  T006 → (T007 ∥ T008)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: T001 (types)
+2. Complete Phase 2: T002 → T003 (settings store, TDD)
+3. Complete Phase 3: T004 → T005 (Settings tab UI)
+4. **STOP and VALIDATE**: Open `/`, click Settings, toggle, reload — persistence works
+5. Ready to demo US1 independently
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Settings store ready
+2. Phase 3 (US1) → Tab UI + toggle functional — demo-able MVP
+3. Phase 4 (US2) → Gameplay respects setting; PuzzlePage cleaned up
+4. Phase 5 (US3) → Visual polish and accessibility
+5. Phase 6 → Full build validation
+
+### Full Sequential Order (single developer)
+
+```
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 → T010 → T011 → T012 → T013 → T014
+```
+
+---
+
+## Notes
+
+- **TDD discipline**: T002 and T006 are "write RED tests" tasks — confirm FAIL before implementing the corresponding store/action changes
+- **No new npm dependencies**: All implementation uses existing Zustand, Tailwind v4, React — `pnpm install` not needed
+- **[P] tasks**: Different files, no shared state — safe to run in parallel
+- Each checkpoint is a valid commit point
+- The toggle in PuzzlePage (T008) can be removed independently of the game-store changes (T007) — different files

--- a/src/pages/PuzzlePage.tsx
+++ b/src/pages/PuzzlePage.tsx
@@ -25,11 +25,9 @@ export default function PuzzlePage() {
     isNewRecord,
     manualMarks,
     autoMarksByQueen,
-    autoMarkEnabled,
     loadStage,
     cycleCell,
     addManualMark,
-    toggleAutoMark,
     restart,
     tick,
     markSolved,
@@ -139,18 +137,6 @@ export default function PuzzlePage() {
 
       {/* Timer */}
       <Timer elapsedSeconds={elapsedSeconds} isRunning={timerRunning} />
-
-      {/* Auto-Mark toggle */}
-      <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
-        <input
-          type="checkbox"
-          checked={autoMarkEnabled}
-          onChange={toggleAutoMark}
-          disabled={isSolved}
-          className="w-4 h-4 cursor-pointer"
-        />
-        Auto-mark invalid cells
-      </label>
 
       {/* Board */}
       <Board

--- a/src/pages/StageSelectPage.tsx
+++ b/src/pages/StageSelectPage.tsx
@@ -1,13 +1,20 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { Crown } from 'lucide-react'
+import { Crown, LayoutGrid, Settings } from 'lucide-react'
 import { STAGES, STAGE_IDS } from '@/lib/stages'
 import { useBestTimesStore } from '@/stores/best-times-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import StageCard from '@/components/StageCard'
+import { cn } from '@/lib/cn'
+
+type ActiveTab = 'stages' | 'settings'
 
 export default function StageSelectPage() {
   const navigate = useNavigate()
   const { bestTimes } = useBestTimesStore()
+  const { autoMarkEnabled, setAutoMark } = useSettingsStore()
+  const [activeTab, setActiveTab] = useState<ActiveTab>('stages')
 
   return (
     <motion.div
@@ -22,20 +29,117 @@ export default function StageSelectPage() {
           <Crown className="w-8 h-8 text-amber-400" strokeWidth={1.5} />
           <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">Queems</h1>
         </div>
-        <p className="text-sm text-gray-500">It's Queens, but with an  <span className="text-2xl font-extrabold  text-amber-400">m</span> .</p>
+        <p className="text-sm text-gray-500">
+          It's Queens, but with an <span className="text-2xl font-extrabold text-amber-400">m</span>.
+        </p>
       </div>
 
+      {/* Tab bar */}
+      <div
+        role="tablist"
+        aria-label="Page sections"
+        className="flex items-center gap-1 bg-gray-100 rounded-full p-1"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'stages'}
+          aria-controls="panel-stages"
+          id="tab-stages"
+          onClick={() => setActiveTab('stages')}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-150',
+            activeTab === 'stages'
+              ? 'bg-amber-400 text-white shadow-sm'
+              : 'text-gray-500 hover:text-gray-700',
+          )}
+        >
+          <LayoutGrid className="w-3.5 h-3.5" strokeWidth={2} />
+          Stages
+        </button>
 
-      <div className="w-full max-w-3xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {STAGE_IDS.map((stageId) => (
-          <StageCard
-            key={stageId}
-            stage={STAGES[stageId]}
-            bestTime={bestTimes[stageId]}
-            onSelect={(id) => navigate(`/stage/${id}`)}
-          />
-        ))}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'settings'}
+          aria-controls="panel-settings"
+          id="tab-settings"
+          onClick={() => setActiveTab('settings')}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-150',
+            activeTab === 'settings'
+              ? 'bg-amber-400 text-white shadow-sm'
+              : 'text-gray-500 hover:text-gray-700',
+          )}
+        >
+          <Settings className="w-3.5 h-3.5" strokeWidth={2} />
+          Settings
+        </button>
       </div>
+
+      {/* Tab panels */}
+      {activeTab === 'stages' && (
+        <div
+          id="panel-stages"
+          role="tabpanel"
+          aria-labelledby="tab-stages"
+          className="w-full max-w-3xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+        >
+          {STAGE_IDS.map((stageId) => (
+            <StageCard
+              key={stageId}
+              stage={STAGES[stageId]}
+              bestTime={bestTimes[stageId]}
+              onSelect={(id) => navigate(`/stage/${id}`)}
+            />
+          ))}
+        </div>
+      )}
+
+      {activeTab === 'settings' && (
+        <div
+          id="panel-settings"
+          role="tabpanel"
+          aria-labelledby="tab-settings"
+          className="w-full max-w-sm"
+        >
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 divide-y divide-gray-100">
+            {/* Setting row — Auto-mark */}
+            <div className="flex items-center justify-between gap-4 px-5 py-4 min-h-[64px]">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-gray-800">Auto-mark invalid cells</span>
+                <span className="text-xs text-gray-400 leading-snug">
+                  Marks cells that would break the rules when you place a queen
+                </span>
+              </div>
+
+              {/* Toggle switch */}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={autoMarkEnabled}
+                aria-label="Auto-mark invalid cells"
+                onClick={() => setAutoMark(!autoMarkEnabled)}
+                className={cn(
+                  'relative flex-shrink-0 inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400',
+                  autoMarkEnabled ? 'bg-amber-400' : 'bg-gray-200',
+                )}
+              >
+                <span
+                  className={cn(
+                    'inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200',
+                    autoMarkEnabled ? 'translate-x-6' : 'translate-x-1',
+                  )}
+                />
+              </button>
+            </div>
+          </div>
+
+          <p className="mt-3 text-xs text-gray-400 text-center px-2">
+            Settings are saved automatically
+          </p>
+        </div>
+      )}
     </motion.div>
   )
 }

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { CellCoord, CellKey, GameStoreState } from '@/types'
 import { STAGES } from '@/lib/stages'
 import { toggleQueen, isSolved, computeInvalidationSet } from '@/lib/board-state'
+import { useSettingsStore } from '@/stores/settings-store'
 
 export const useGameStore = create<GameStoreState>((set, get) => ({
   stageId: '',
@@ -12,7 +13,7 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
   isNewRecord: false,
   manualMarks: [],
   autoMarksByQueen: {},
-  autoMarkEnabled: false,
+  autoMarkEnabled: true,
 
   loadStage(stageId: string) {
     set({
@@ -24,7 +25,7 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
       isNewRecord: false,
       manualMarks: [],
       autoMarksByQueen: {},
-      autoMarkEnabled: false,
+      autoMarkEnabled: useSettingsStore.getState().autoMarkEnabled,
     })
   },
 
@@ -69,7 +70,7 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
       const newManualMarks = state.manualMarks.filter((k) => k !== key)
       const newQueens = [...state.queens, { row: coord.row, col: coord.col }]
 
-      // Apply auto-marks for the newly placed queen if toggle is on
+      // Apply auto-marks for the newly placed queen if auto-mark is enabled
       let newAutoMarksByQueen = state.autoMarksByQueen
       if (state.autoMarkEnabled) {
         const stage = STAGES[state.stageId]
@@ -110,30 +111,6 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
     if (Object.values(state.autoMarksByQueen).some((cells) => cells.includes(key))) return
 
     set({ manualMarks: [...state.manualMarks, key] })
-  },
-
-  toggleAutoMark() {
-    const state = get()
-    const newEnabled = !state.autoMarkEnabled
-
-    if (newEnabled) {
-      // Retroactively apply auto-marks for all currently placed queens
-      const stage = STAGES[state.stageId]
-      if (stage) {
-        const newAutoMarksByQueen: Record<string, CellKey[]> = {}
-        for (const queen of state.queens) {
-          const qKey: CellKey = `${queen.row}:${queen.col}`
-          const invalidCells = computeInvalidationSet(queen, stage)
-          newAutoMarksByQueen[qKey] = invalidCells.map(
-            (c) => `${c.row}:${c.col}` as CellKey,
-          )
-        }
-        set({ autoMarkEnabled: true, autoMarksByQueen: newAutoMarksByQueen })
-        return
-      }
-    }
-
-    set({ autoMarkEnabled: newEnabled })
   },
 
   restart() {

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { SettingsState } from '@/types'
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      autoMarkEnabled: true,
+
+      setAutoMark(value: boolean) {
+        set({ autoMarkEnabled: value })
+      },
+    }),
+    {
+      name: 'queems-settings',
+    },
+  ),
+)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,6 @@ export interface GameStoreState extends GameSession {
    * no auto-mark). Calling on a non-empty cell is a no-op. Used by drag marking.
    */
   addManualMark: (coord: CellCoord) => void
-  toggleAutoMark: () => void
   restart: () => void
   tick: () => void
   markSolved: (elapsedSeconds: number, isNewRecord: boolean) => void
@@ -76,6 +75,16 @@ export interface BestTimesState {
   bestTimes: Record<string, number>
   saveBestTime: (stageId: string, seconds: number) => void
   getBestTime: (stageId: string) => number | undefined
+}
+
+// ─── App Settings (persisted Zustand store) ──────────────────────────────────
+
+export interface AppSettings {
+  autoMarkEnabled: boolean
+}
+
+export interface SettingsState extends AppSettings {
+  setAutoMark: (value: boolean) => void
 }
 
 // ─── Pure function type aliases ───────────────────────────────────────────────

--- a/tests/logic/game-store.test.ts
+++ b/tests/logic/game-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useGameStore } from '@/stores/game-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { CellKey } from '@/types'
 
 // Reset the store to a clean empty board before each test.
@@ -17,6 +18,20 @@ function resetStore() {
     autoMarkEnabled: false,
   })
 }
+
+describe('loadStage', () => {
+  it('initializes autoMarkEnabled from the settings store when setting is ON', () => {
+    useSettingsStore.setState({ autoMarkEnabled: true })
+    useGameStore.getState().loadStage('stage-1')
+    expect(useGameStore.getState().autoMarkEnabled).toBe(true)
+  })
+
+  it('initializes autoMarkEnabled from the settings store when setting is OFF', () => {
+    useSettingsStore.setState({ autoMarkEnabled: false })
+    useGameStore.getState().loadStage('stage-1')
+    expect(useGameStore.getState().autoMarkEnabled).toBe(false)
+  })
+})
 
 describe('addManualMark', () => {
   beforeEach(() => {

--- a/tests/logic/settings-store.test.ts
+++ b/tests/logic/settings-store.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSettingsStore } from '@/stores/settings-store'
+
+function resetStore() {
+  useSettingsStore.setState({ autoMarkEnabled: true })
+}
+
+describe('useSettingsStore', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('defaults autoMarkEnabled to true', () => {
+    const { autoMarkEnabled } = useSettingsStore.getState()
+    expect(autoMarkEnabled).toBe(true)
+  })
+
+  it('setAutoMark(false) sets autoMarkEnabled to false', () => {
+    useSettingsStore.getState().setAutoMark(false)
+    expect(useSettingsStore.getState().autoMarkEnabled).toBe(false)
+  })
+
+  it('setAutoMark(true) restores autoMarkEnabled to true after it was false', () => {
+    useSettingsStore.setState({ autoMarkEnabled: false })
+    useSettingsStore.getState().setAutoMark(true)
+    expect(useSettingsStore.getState().autoMarkEnabled).toBe(true)
+  })
+
+  it('setAutoMark is idempotent — calling with the same value leaves state unchanged', () => {
+    useSettingsStore.getState().setAutoMark(true)
+    expect(useSettingsStore.getState().autoMarkEnabled).toBe(true)
+
+    useSettingsStore.getState().setAutoMark(false)
+    useSettingsStore.getState().setAutoMark(false)
+    expect(useSettingsStore.getState().autoMarkEnabled).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #17

## Summary

- **New `settings-store.ts`** — Zustand `persist` store (`queems-settings` in localStorage). Holds `autoMarkEnabled` (default `true`) with `setAutoMark` action.
- **Settings tab on Stage Select** — Tabbed layout (Stages / Settings). The Settings panel exposes an accessible `role="switch"` toggle for auto-marking.
- **Auto-mark moved out of PuzzlePage** — The inline checkbox is removed; `loadStage` now seeds `autoMarkEnabled` from the settings store so the value persists across sessions.
- **`toggleAutoMark` removed** — Replaced by the settings-store action; `GameStoreState` interface updated accordingly.
- **4 new unit tests** for `settings-store`; game-store tests extended. All **59 tests pass**.

## Test plan

- [ ] Toggle Auto-mark off in Settings tab → start a puzzle → queens placed, no auto-X marks appear
- [ ] Toggle Auto-mark on → start a puzzle → invalid cells are marked automatically on queen placement
- [ ] Reload the page → setting persists (check `localStorage["queems-settings"]`)
- [ ] Keyboard-navigate to the toggle (`Tab` key) → focus ring visible, `Space` activates it
- [ ] All Vitest tests pass (`pnpm vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)